### PR TITLE
Feature/dependency handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.DS_Store
+.project
+.metadata
+.classpath
+.settings/
+target/
+.idea/
+*.iml
+*.ipr
+*.iws
+/nbactions.xml
+.checkstyle
+.externalToolBuilders
+maven-eclipse.xml

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>aem-package-maven-plugin</artifactId>
     <name>AEM Package Maven Plugin</name>
     <description>Uploads, installs, and/or replicates the package artifact for a Maven project to AEM Package Manager.</description>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <organization>

--- a/src/main/java/com/icfolson/maven/plugins/aempackage/mojo/InstallPackageMojo.java
+++ b/src/main/java/com/icfolson/maven/plugins/aempackage/mojo/InstallPackageMojo.java
@@ -19,7 +19,7 @@ public final class InstallPackageMojo extends AbstractPackageMojo {
     private boolean installRecursive;
 
     @Parameter(property = "aem.package.install.dependencyHandling", defaultValue = "required")
-    private String dependencyHandling;
+    protected String dependencyHandling;
 
     @Override
     public ResponseFormat getResponseFormat() {

--- a/src/main/java/com/icfolson/maven/plugins/aempackage/mojo/InstallPackageMojo.java
+++ b/src/main/java/com/icfolson/maven/plugins/aempackage/mojo/InstallPackageMojo.java
@@ -18,6 +18,9 @@ public final class InstallPackageMojo extends AbstractPackageMojo {
     @Parameter(property = "aem.package.install.recursive", defaultValue = "false")
     private boolean installRecursive;
 
+    @Parameter(property = "aem.package.install.dependencyHandling", defaultValue = "required")
+    private String dependencyHandling;
+
     @Override
     public ResponseFormat getResponseFormat() {
         return ResponseFormat.JSON;
@@ -28,6 +31,7 @@ public final class InstallPackageMojo extends AbstractPackageMojo {
         final Map<String, String> parameters = Maps.newHashMap();
 
         parameters.put("recursive", Boolean.toString(installRecursive));
+        parameters.put("dependencyHandling", dependencyHandling);
 
         return parameters;
     }

--- a/src/test/groovy/com/icfolson/maven/plugins/aempackage/http/PackageManagerHttpClientSpec.groovy
+++ b/src/test/groovy/com/icfolson/maven/plugins/aempackage/http/PackageManagerHttpClientSpec.groovy
@@ -48,6 +48,8 @@ class PackageManagerHttpClientSpec extends Specification {
 
         init(mojo)
 
+        mojo.dependencyHandling = "required"
+
         def httpClient = new PackageManagerHttpClient(mojo)
 
         when:


### PR DESCRIPTION
Added dependencyHandling as an option to the installation.  This is both a valid option and needed at the moment to get around a defect in subpackage handling introduced in AEM 6.3.